### PR TITLE
Refresh research paper -- lessons from June 2026

### DIFF
--- a/RESEARCH_PAPER.md
+++ b/RESEARCH_PAPER.md
@@ -4,7 +4,7 @@
 **Target instrument:** XAUUSD (spot gold), MetaTrader 5
 **Target account:** The5ers prop-firm challenge, $5,000 tier
 **Initial draft:** April 2026
-**Last updated:** May 2026
+**Last updated:** July 2026
 
 ---
 
@@ -311,6 +311,29 @@ When the Python process reconciles open positions with MT5 on reconnect, the bro
 
 ---
 
+**Lesson 19: Physically deleting kill-listed strategy files eliminates the silent re-enable risk that remains when code is present but disabled in config.**
+After six strategies (`breakout`, `mean_reversion`, `supply_demand`, `descending_channel_breakout`, `mini_medallion`, `continuation_breakout`) had been disabled in live configs for several weeks with no improvement in audit evidence, their source files were removed from the codebase entirely (2026-06-10). While `confluence_gate.py` already maintained a `KILL_LIST` set that blocks these names even if a stale config re-enables them, having the code present left an ambiguity about which config state is authoritative. Git history preserves the deleted code for reference. The lesson: a kill-list in a runtime gate is defence-in-depth; physical deletion is the primary control.
+
+**Lesson 20: Loser-profile dissection — grouping losing trades by the candidate filter's value — identifies non-overfit filters when the bad cohort is negative in both in-sample and out-of-sample windows.**
+For `squeeze_breakout`, sorting losing trades by penetration depth and ATR expansion ratio revealed two reliably unprofitable cohorts: shallow penetration below 0.1×ATR (win rate 22%, −$1,246 full-span) and weak ATR expansion between 1.02–1.05× (−$1,125, versus +$3,096 above 1.10×). Adding `min_penetration_atr` and `atr_expansion_ratio` entry gates improved profit factor from 1.12 to 1.21 on the 2026 in-sample year and from 1.05 to 1.42 on the 2025 out-of-sample year (`scripts/analyze_squeeze_losers.py`, `scripts/analyze_stoch_losers.py`, 2026-06-22). When a filter improves the out-of-sample result by a larger margin than it improves the in-sample result, the filter is unlikely to be data-mined; the reverse — IS improvement greater than OOS — is the normal signature of overfitting.
+
+**Lesson 21: A higher-timeframe trend alignment gate applied to a volatility-coil breakout strategy produced monotonic lift across both in-sample and out-of-sample periods; a session-hour filter did not.**
+The `htf_ema_period` gate for `squeeze_breakout` (default EMA400 on 15m ≈ EMA100 on 1H) restricts entries to breaks aligned with the slow EMA — BUY only when price is above, SELL only below. Sweeping EMA lengths from 100 to 600 showed strictly monotonic improvement in both the 2026 IS year and the 2025 OOS year (`scripts/research_squeeze_htf_gate.py`, 2026-06-22). Production backtest improved from PF 1.21 to PF 1.44, max drawdown from −6.25% to −5.85%, on 273 trades versus 407 pre-gate. Critically, the gated version survives `--enforce-risk` kill-switch enforcement at $5k (PF 1.44–1.61 depending on tier), while the pre-gate version throttled to near-flat (PF ~1.00). A session-hour filter was also tested on the same strategy and refuted: all-hours and session-restricted variants performed identically on gold, illustrating that not every structurally plausible gate holds empirically.
+
+**Lesson 22: Under prop-firm risk caps, minimum lot floors interact with the trailing-drawdown kill switch in a way that makes some strategies account-size-dependent.**
+`stoch_pullback` on XAUUSD passes walk-forward validation at $25k+ but halts after approximately 10 trades under `--enforce-risk` at $5k. The mechanism is not a flaw in the strategy's edge: at $5k with a $15/trade risk budget, ATR-implied lot sizes fall below MT5's minimum lot (0.02 on gold), and the system floors at min_lot. Gold's wide structural stops at min_lot risk approximately $78/trade — roughly 5× the intended budget. Three consecutive losses at that exposure consume $234 of the $250 max-drawdown limit, triggering the kill switch before positive expectancy has time to emerge. The same signals survive enforcement at $25k, where the implied lot exceeds the floor. This failure mode is invisible in flat-cost backtests and appears only when `--enforce-risk` replays the actual risk-engine veto logic. Calendar strategies (`index_overnight`, `wednesday_drift`, `london_breakout`, `monday_drift`) survive enforcement at all tiers because their time-stop exits produce smaller per-trade losses and their drawdown paths remain well below the kill-switch threshold.
+
+**Lesson 23: Broker instrument availability must be confirmed against the live MT5 account before a research-validated strategy is propagated to production configs.**
+`index_overnight` was designed to run on US30, NAS100, and GER40 based on independent statistical significance across all three indices (Turnaround Tuesday t-statistics: NAS t=2.17, US30 t=1.83, GER40 t=2.72; research PF 1.58–1.74). All three were propagated to all eight account-tier configs, regime weight tables, symbol reconciler maps, and test suites (commit `06b6233`, 2026-06-24). Within 24 hours, live broker inspection showed that NAS100 and GER40 index CFDs are not offered on the live MT5 account; the broker's "NASDAQ" group is cash equities, warrants, and ETFs, none of which carry the overnight drift. Both symbols were stripped from all configs and code (commits `a15e0fe`, `f08a53a`, 2026-06-25). The lesson: a strategy's statistical validity on historical data and its live instrument availability are independent checks; the latter must precede any config propagation, not follow it.
+
+**Lesson 24: Two correlated strategies on the same instrument can consume the max-positions budget as a single directional bet rather than as two independent trades.**
+`squeeze_breakout` and `stoch_pullback` both trade XAUUSD on 15-minute bars with the gold trend as a shared factor. Correlation analysis across 2026 return tapes showed a +0.34 pairwise correlation — the only materially off-diagonal entry in the full seven-strategy roster (`scripts/research_portfolio_correlation.py`, `scripts/handcraft_weights.py`, 2026-06-23). Applying Rob Carver's handcrafting method over the correlation-distance tree produced an Instrument Diversification Multiplier of 1.76 versus 2.09 for naive equal-weight, meaning the pair provides only 1.76 independent bets per concurrent position. A new correlation guard (risk check 18, `src/risk/risk_engine.py`, commit `f54d836`, 2026-06-23) caps concurrent open positions per correlation cluster (default cluster size 1), so the two gold breakout strategies cannot simultaneously occupy both `max_positions` slots with aligned-direction signals. This guard is baked in as a default across all configs; the cluster definition is configurable via `risk.correlation_guard`.
+
+**Lesson 25: Deriving the live stop-loss distance from a fixed config value in points rather than from the operator's dollar-risk budget caused strategies to risk 4.4× the intended per-trade maximum.**
+An intermediate implementation on 2026-06-30 added `sl_points` fields to strategy config blocks and used them as the stop distance directly (commits `99a5086`, `7136ac5`). At that parameterisation, a 33-point stop on gold at 0.2 lots risks approximately $66, while the same config's `risk_per_trade_usd: 15` intended $15 — a 4.4× overrun that bypassed the operator's start-script max-loss input entirely. The correct execution path — restored in the same-day fix (commit `eb5c15a`) — derives the stop distance at execution time as `risk_per_trade_usd / (lot × value_per_lot)` (BudgetSL) and sets TP as `reward_risk_ratio × sl_dist` immediately after BudgetSL. Strategies with validated native stops (`squeeze_breakout`, `stoch_pullback`, `london_breakout`, `monday_drift`, `index_overnight`, `wednesday_drift`) bypass BudgetSL via the `preserve_structural_sl` metadata flag and retain their precomputed levels. The generalised lesson: any execution path that has more than one mechanism for expressing a stop-loss must have a documented override precedence; without one, a later addition silently takes priority over earlier constraints.
+
+---
+
 ## 19. Limitations and Future Work
 
 - **XAUUSD concentration.** The system is designed and validated exclusively on gold. Extension to other instruments (BTC/ETH/EURUSD) requires separate regime classifier training, independent audit periods, and instrument-specific risk limits. The $250 max-drawdown constraint of the $5k tier is too tight for BTC/ETH under Kalman sizing (see Lesson 16).
@@ -325,6 +348,10 @@ When the Python process reconciles open positions with MT5 on reconnect, the bro
 
 - **No live options or hedging instruments.** Downside protection during high-impact news events relies entirely on the news blackout. Adding a systematic hedge (e.g. a gold inverse ETF) during risk-off periods would reduce drawdown path variance at the cost of implementation complexity.
 
+- **Calendar and seasonal strategies carry macro-regime decay risk without automated detection.** `monday_drift`, `london_breakout`, `index_overnight`, and `wednesday_drift` harvest statistical drift patterns present over the 2024–2026 research window — anti-USD trend, Turnaround Tuesday equity rebound, and mid-week JPY carry. These effects are correlated with the prevailing macro regime and will decay or reverse when underlying conditions change. Only `monday_drift` has an explicit regime kill-switch (daily SMA gate); the other three strategies have no macro-level protection beyond the universal kill switch. Performance decay in these strategies is currently detected only retrospectively through the weekly audit.
+
+- **Broker instrument availability is not programmatically verified during config propagation.** The NAS100 episode (Lesson 23) demonstrated that research-side instrument availability (Dukascopy historical data) and live MT5 account availability are independent dimensions. A new strategy's symbol must be confirmed available — and its contract spec (min_lot, value_per_lot, overnight financing) verified against the broker's MT5 symbol info — before config propagation. This check is currently manual via `scripts/health_check.py`; it is not enforced automatically when a new symbol block is added to a config file.
+
 ---
 
 ## 20. Conclusion
@@ -333,4 +360,4 @@ The system demonstrates that a multi-strategy quantitative trading system can be
 
 ---
 
-*End of document. Last lesson added: Lesson 18 (2026-05-30). Next scheduled review: 2026-07-01.*
+*End of document. Last lesson added: Lesson 25 (2026-07-01). Next scheduled review: 2026-08-01.*

--- a/RESEARCH_PAPER.md
+++ b/RESEARCH_PAPER.md
@@ -4,7 +4,7 @@
 **Target instrument:** XAUUSD (spot gold), MetaTrader 5
 **Target account:** The5ers prop-firm challenge, $5,000 tier
 **Initial draft:** April 2026
-**Last updated:** July 2026
+**Last updated:** August 2026
 
 ---
 
@@ -334,6 +334,29 @@ An intermediate implementation on 2026-06-30 added `sl_points` fields to strateg
 
 ---
 
+**Lesson 26: A structural-stop strategy that sizes lots from a per-trade USD budget silently fails the risk engine if the operator cap sits below the sizer's worst-case output.**
+The BOSStructure strategy (SMC break-of-structure sequence; added 2026-07-07, `src/strategies/bos_structure_strategy.py`) produced near-zero enforced-risk backtest trades despite positive research results: the ATR-scaled structural stop generated per-trade lot sizes of $110–230 while the operator cap was $119.70, so `RiskEngine.validate_order` rejected virtually every signal silently — no logged error, no trade. Root-cause was confirmed by instrumenting `validate_order` (2026-07-09). The fix was `risk.strategy_risk_overrides.bos_structure.risk_per_trade_pct: 0.0048` in all eight live configs, lifting the cap just above the sizer's typical output; the enforced-risk 2026 backtest moved from PF 0.56/halted to PF 1.11 (+$131, DD −2.2%), the strategy's first positive enforced result. The general form of this failure: a tight per-trade-USD cap combined with a structural stop produces silent order rejection, not reduced position size — the sizer's output is all-or-nothing against the cap.
+
+**Lesson 27: A 96-variant redesign of a rejected strategy lifted in-sample profit factor but failed the "positive every calendar year" gate due to single-year regime dependency.**
+EMA200Nasdaq was disabled in all live configs on 2026-07-08 (raw PF 0.58, enforced PF 0.19) after confirming negative expectancy in every period. A v2 redesign (`scripts/research_ema200_v2.py`, 2026-07-08) added five independent improvements: DST-aware cash-open anchor, overnight-range bias, daily-EMA20 trend filter, pullback-limit entry, and a 1×ATR stop floor. Every individual fix helped directionally, and the best combined cell lifted PF from 0.58 to 1.37. The year breakdown was 1.06 / 2.13 / 1.10 across three calendar years: 0 of 96 cells passed the gate requiring positive or flat performance in every year. Pullback-limit entry proved monotonically worse than chase entry (limit-fill adverse selection), contradicting the rationale for adding it. The NY-open anchor-break family on this instrument is not researchable further; the 2025 year dominance tracks the Nasdaq bull leg and is regime beta, not alpha.
+
+**Lesson 28: The M1 gold tick scalper family cannot reach breakeven even at institutional cost levels; the micro-reversion edge is genuine but roughly 1/14th the typical spread.**
+An exhaustive 480-cell parameter grid (`scripts/backtest_gold_tick_scalper.py`, 2026-07-29) tested burst-fade and burst-continuation scalpers on XAUUSD 1-minute Dukascopy ticks across session, trigger threshold, stop width, target, and direction axes. At the observed median spread of 0.69 pips, PF was stable at approximately 0.78 across all cells; IS and OOS halves matched within ±0.03, confirming this is measurement of stable underperformance rather than overfitting. A zero-cost limit test confirmed the ceiling: reducing the synthetic spread from 0.69 to 0.02 (better than institutional pricing) pushes PF from 0.42 to 0.979 — it asymptotes below 1.0 and never crosses. The micro-reversion tendency is real (+0.05–0.10 pips at 30 seconds, positive 9 of 9 days in forward-move analysis), but it is consumed entirely by spread and TP/SL geometry. Profitable tick-scalping on gold requires earning the spread through passive quoting with co-location priority rather than paying it on each fill.
+
+**Lesson 29: A parameter plateau measured on a contaminated sample is not evidence of robustness; only a holdout drawn from data that played no role in filter selection can detect this failure.**
+In the M1 Cardwell RSI reversal research (2026-07-29, `reports/rsi_reversal_m1_research.md`), restricting entries to 13–16 UTC produced PF 1.668 across 56 days, with all 12 neighbouring cells (time-stop × RR grid) profitable in both IS and OOS halves of that sample, and PF still 1.62 at 10× modelled slippage. This passed every standard robustness check. A true holdout of 68 days fetched after the session window was fixed showed PF 0.446, with the win rate collapsing from 51.2% to 22.1% and no session window working on the holdout data. The root cause: the 13–16 UTC session was selected by scanning all 56 days, which contaminated both halves of any split drawn from that sample simultaneously — the plateau and cost-robustness evidence were measured on contaminated data and gave false confidence. The remedy: any filter chosen by looking at data (session, side, regime, symbol) must be validated on a holdout drawn from data that existed but was withheld before the filter decision was made, not on a later split of the same sample.
+
+**Lesson 30: A "close basket when in profit" rule produces a 100% closed-trade win rate and deeply negative equity simultaneously; realized P&L and true equity diverge by the amount warehoused in floating losses.**
+A no-stop-loss basket (`scripts/research_basket_close_m1.py`, 2026-07-29) opened 0.01-lot positions at every M1 close and exited all positions when total floating P&L crossed $0.01 positive. Over 56 days, all 9,089 cycles closed green, generating +$4,192 in realised gains; concurrently, the true account equity fell to −$59,815 from −$64,007 in unrealised losses that were never booked. The mechanism: a rule that can only close when in profit cannot produce a losing closed trade by definition — it sorts outcomes rather than improving them, realizing winners and warehousing losers indefinitely. Capping position count to 5 or 20 reduced the magnitude of the loss but did not change the sign. Any evaluation framework that reports only closed-trade statistics will classify this system as a consistent winner; the assessment requires mark-to-market equity including all open positions.
+
+**Lesson 31: A pre-trained zero-shot neural network on gold shows measurable but cost-insufficient predictive signal; a structured IC pipeline now provides pre-screening before full backtest investment.**
+A two-stage IC smell-test pipeline (`scripts/kronos_smelltest.py`, commits `f74bd27`–`8f2746d`, 2026-07-28) was built to evaluate the NeoQuasar/Kronos-base model on XAUUSD and BTCUSD 15m data. Stage 1 measures Spearman IC per prediction horizon and calendar year; Stage 2 runs a strict-fill toy simulation to convert the IC signal into a profit factor. On XAUUSD, h1 IC reached 0.067 — above the 0.03 floor indicating some directional information exists — but the strict-fill PF was 0.81, below the 1.1 passing threshold (reports `reports/kronos_ic_smelltest_XAUUSD.md`, `reports/kronos_ic_smelltest_BTCUSD.md`). BTCUSD failed the IC floor outright (h3 IC 0.028). The pipeline design generalises: a model that passes Stage 1 but fails Stage 2 has real signal that the cost structure consumes entirely; a model that fails Stage 1 is uninformative regardless of exit engineering. This pipeline now serves as the mandatory pre-screen for any external ML model before committing research resources to a full backtest.
+
+**Lesson 32: A strategy's standalone edge evaluated over a period that coincides with its favourable regime will overstate durability; a multi-regime spanning window is the minimum credible bar.**
+A longer out-of-sample gate (`scripts/validate_squeeze_longoos.py`, report `reports/squeeze_breakout_longoos.md`, 2026-07-22) evaluated squeeze-breakout over 16 months (2025Q1 through 2026Q2, 569 signals). Full-span profit factor was 1.15, but only 3 of 6 quarters were profitable; 2025Q3 produced PF 0.39 (−$2,036) and the drop-best-quarter PF fell to 1.05. The earlier 2026-only validation had returned a strong positive result because 2026 happened to contain the strategy's best quarters. The correlation with KalmanRegime is structural and confirmed in both years (ρ +0.20 in 2025, +0.13 in 2026), so the strategy retains diversification value at a decay-floored weight. The lesson: a single-year or short-window validation that coincides with the strategy's favourable regime is indistinguishable from a validation of the regime itself; the "drop best quarter" robustness check does not catch this if the window contains only the good quarters.
+
+---
+
 ## 19. Limitations and Future Work
 
 - **XAUUSD concentration.** The system is designed and validated exclusively on gold. Extension to other instruments (BTC/ETH/EURUSD) requires separate regime classifier training, independent audit periods, and instrument-specific risk limits. The $250 max-drawdown constraint of the $5k tier is too tight for BTC/ETH under Kalman sizing (see Lesson 16).
@@ -352,6 +375,8 @@ An intermediate implementation on 2026-06-30 added `sl_points` fields to strateg
 
 - **Broker instrument availability is not programmatically verified during config propagation.** The NAS100 episode (Lesson 23) demonstrated that research-side instrument availability (Dukascopy historical data) and live MT5 account availability are independent dimensions. A new strategy's symbol must be confirmed available — and its contract spec (min_lot, value_per_lot, overnight financing) verified against the broker's MT5 symbol info — before config propagation. This check is currently manual via `scripts/health_check.py`; it is not enforced automatically when a new symbol block is added to a config file.
 
+- **IS/OOS splits cannot detect contamination from a prior filter-selection step.** Any hyperparameter chosen by scanning the full dataset (session window, side, regime, symbol) contaminates every split of that dataset simultaneously. The RSI M1 session-window false positive (Lesson 29) demonstrated that a plateau check, IS/OOS consistency, and cost-robustness can all produce positive readings on contaminated data. No improvement to the IS/OOS protocol repairs this; the only remedy is a holdout drawn from data that was withheld before the selection decision.
+
 ---
 
 ## 20. Conclusion
@@ -360,4 +385,4 @@ The system demonstrates that a multi-strategy quantitative trading system can be
 
 ---
 
-*End of document. Last lesson added: Lesson 25 (2026-07-01). Next scheduled review: 2026-08-01.*
+*End of document. Last lesson added: Lesson 32 (2026-07-29). Next scheduled review: 2026-09-01.*


### PR DESCRIPTION
## Summary

Scheduled monthly audit of `RESEARCH_PAPER.md`. Seven new empirical lessons and two new limitation bullets, covering all material production decisions made in June 2026. No existing lessons were modified or renumbered.

**New lessons added to Section 18:**

- **Lesson 19** — Kill-list strategy file deletion (2026-06-10): physical deletion is safer than config-disable + gate defence because it eliminates the ambiguity of which config is authoritative.
- **Lesson 20** — Loser-profile dissection technique: grouping losing trades by candidate filter value identifies non-overfit filters when the bad cohort is negative on both IS and OOS windows. Demonstrated on `squeeze_breakout` penetration depth and ATR expansion ratio (commits `56ae2a1`, 2026-06-22).
- **Lesson 21** — HTF trend alignment gate for `squeeze_breakout`: EMA400-on-15m monotonically improved both IS (2026) and OOS (2025) at every EMA length tested; session-hour filter was refuted on the same strategy. Production PF 1.21 → 1.44; kill-switch survival restored at $5k (`scripts/research_squeeze_htf_gate.py`, 2026-06-22).
- **Lesson 22** — Account-size-dependent strategy viability: min-lot floors on gold interact with the trailing-DD kill switch, making `stoch_pullback` unviable at $5k (kills after ~10 trades) but viable at $25k+. Invisible in flat-cost backtests; revealed by `--enforce-risk` replay.
- **Lesson 23** — Broker instrument availability vs. research data availability: NAS100 and GER40 were fully wired into all configs (commit `06b6233`, 2026-06-24) and removed 24 hours later when broker inspection showed neither index CFD exists on the live account (commits `a15e0fe`, `f08a53a`, 2026-06-25). Availability check must precede config propagation.
- **Lesson 24** — Correlated-strategy max-positions exhaustion: `squeeze_breakout` × `stoch_pullback` correlate +0.34 (only material off-diagonal in the roster); handcrafting IDM 1.76 vs. 2.09 equal-weight. New risk check 18 (correlation guard, `src/risk/risk_engine.py`, commit `f54d836`, 2026-06-23) caps concurrent positions per cluster.
- **Lesson 25** — BudgetSL vs. fixed config points: intermediate commits `99a5086`/`7136ac5` on 2026-06-30 hard-coded `sl_points` in config, risking 4.4× the intended dollar loss. Fixed same day (commit `eb5c15a`) by deriving stop distance as `risk_per_trade_usd / (lot × value_per_lot)` at execution time; `preserve_structural_sl` flag exempts strategies with validated native stops.

**New limitations added to Section 19:**

- Calendar/seasonal strategies (monday_drift, london_breakout, index_overnight, wednesday_drift) carry macro-regime decay risk; only monday_drift has an automated regime gate.
- Broker instrument availability is not programmatically verified during config propagation; manual `health_check.py` inspection is required.

**Supporting commits:** `56ae2a1`, `f54d836`, `69a0059`, `12aba76`, `a15e0fe`, `f08a53a`, `1e3e6f7`, `eb5c15a` (all 2026-06-22 – 2026-06-30).

@vrd07 — please review for accuracy before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHFpFiLK1sbCMwWLUwBdrc)_